### PR TITLE
Adds back SecureRandom.hex

### DIFF
--- a/doc/SecureRandom.html
+++ b/doc/SecureRandom.html
@@ -43,7 +43,7 @@
       
         <section id="moduledoc" class="docstring">
           <p>Takes my favorite hits from Ruby’s SecureRandom and brings em to elixir.
-Mostly a convienance wrapper around Erlangs Crypo library, converting 
+Mostly a convienance wrapper around Erlangs Crypto library, converting 
 Crypto.strong_rand_bytes/1 into a string.</p>
 <h2>Examples</h2>
 <pre><code>iex&gt; SecureRandom.base64
@@ -67,6 +67,13 @@ iex&gt; SecureRandom.uuid
   <td class="summary_signature"><a href="#base64/1">base64(n \\ 16)</a></td>
   
     <td class="summary_synopsis"><p>Returns random Base64 encoded string</p>
+</td>
+  
+</tr>
+<tr>
+  <td class="summary_signature"><a href="#hex/1">hex(n \\ 16)</a></td>
+  
+    <td class="summary_synopsis"><p>Generates a random hexadecimal string</p>
 </td>
   
 </tr>
@@ -118,6 +125,28 @@ iex&gt; SecureRandom.uuid
 
 iex&gt; SecureRandom.base64(8)
 &quot;2yDtUyQ5Xws=&quot;</code></pre>
+
+  </section>
+  
+</section>
+<section class="detail">
+  <div class="detail_header" id="hex/1">
+    <span class="signature"><strong>hex(n \\ 16)</strong></span>
+    <div class="detail_header_links">
+      <span class="detail_type">(function)</span>
+      <a href="#hex/1" class="detail_link" title="Link to this function">#</a>
+      <a class="to_top_link" href="#content" title="To the top of the page">&uarr;</a>
+    </div>
+  </div>
+  
+  <section class="docstring">
+    <p>Generates a random hexadecimal string.</p>
+<p>The argument n specifies the length, in bytes, of the random number to be generated. The length of the resulting hexadecimal string is twice n.</p>
+<p>If n is not specified, 16 is assumed. It may be larger in future.</p>
+<p>The result may contain 0-9 and a-f.</p>
+<h2>Examples</h2>
+<pre><code>iex&gt; SecureRandom.hex(6)
+&quot;34fb5655a231&quot;</code></pre>
 
   </section>
   

--- a/doc/modules_list.html
+++ b/doc/modules_list.html
@@ -52,6 +52,11 @@
       </li>
     
       <li>
+        <a href="SecureRandom.html#hex/1" title="SecureRandom.hex/1" class="object_link">hex/1</a>
+        <span class="node_name">SecureRandom</span>
+      </li>
+    
+      <li>
         <a href="SecureRandom.html#random_bytes/1" title="SecureRandom.random_bytes/1" class="object_link">random_bytes/1</a>
         <span class="node_name">SecureRandom</span>
       </li>

--- a/doc/overview.html
+++ b/doc/overview.html
@@ -39,7 +39,7 @@
   <td class="summary_signature"><a href="SecureRandom.html">SecureRandom</a></td>
   
     <td class="summary_synopsis"><p>Takes my favorite hits from Ruby’s SecureRandom and brings em to elixir.
-Mostly a convienance wrapper around Erlangs Crypo library, converting 
+Mostly a convienance wrapper around Erlangs Crypto library, converting 
 Crypto.strong_rand_bytes/1 into a string</p>
 </td>
   

--- a/lib/secure_random.ex
+++ b/lib/secure_random.ex
@@ -39,11 +39,10 @@ defmodule SecureRandom do
     |> to_string
   end
 
-  defp bytes_to_int(bytes, result \\ 0) do
+  defp bytes_to_int(bytes) do
     case bytes do
-      <<>>              -> result
-      <<x>>             -> (result <<< 8) + x
-      <<x, xs::binary>> -> bytes_to_int(xs, (result <<< 8) + x)
+      <<x>>             -> x
+      <<x, xs::binary>> -> (bytes_to_int(xs) <<< 8) + x
     end
   end
 

--- a/lib/secure_random.ex
+++ b/lib/secure_random.ex
@@ -1,4 +1,6 @@
 defmodule SecureRandom do
+  use Bitwise
+
   @moduledoc """
   Takes my favorite hits from Ruby's SecureRandom and brings em to elixir.
   Mostly a convienance wrapper around Erlangs Crypto library, converting 
@@ -35,6 +37,35 @@ defmodule SecureRandom do
     random_bytes(n)
     |> :base64.encode_to_string
     |> to_string
+  end
+
+  defp bytes_to_int(bytes, result \\ 0) do
+    case bytes do
+      <<>>              -> result
+      <<x>>             -> (result <<< 8) + x
+      <<x, xs::binary>> -> bytes_to_int(xs, (result <<< 8) + x)
+    end
+  end
+
+  @doc """
+  Generates a random hexadecimal string.
+
+  The argument n specifies the length, in bytes, of the random number to be generated. The length of the resulting hexadecimal string is twice n.
+
+  If n is not specified, 16 is assumed. It may be larger in future.
+
+  The result may contain 0-9 and a-f.
+
+  ## Examples
+
+      iex> SecureRandom.hex(6)
+      "34fb5655a231"
+  """
+  def hex(n \\ @default_length) do
+    random_bytes(n)
+    |> bytes_to_int
+    |> Integer.to_string(16)
+    |> String.downcase
   end
  
   @doc """

--- a/test/secure_random_test.exs
+++ b/test/secure_random_test.exs
@@ -14,6 +14,15 @@ defmodule SecureRandomTest do
     assert 4 == byte_size(SecureRandom.base64(3))
   end
 
+  test "hex/1 defaults to a byte size of 16" do
+    # The byte size of the resulting string is twice as large
+    assert 32 == byte_size(SecureRandom.hex)
+  end
+
+  test "hex/1 successfully takes a byte length" do
+    assert 12 == byte_size(SecureRandom.hex(6))
+  end
+
   test "urlsafe_base64/1 returns a Binary string" do
     assert is_binary(SecureRandom.urlsafe_base64)
   end


### PR DESCRIPTION
This adds back the hex method.  I implemented it mostly the same as the Ruby version, with the exception that calling `SecureRandom.hex(nil)` will not silently use the default of 16.  `SecureRandom.hex()` will use the default.
