### PR TITLE
Add crypto module in application lists

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule SecureRandom.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :crypto]]
   end
 
   defp package do


### PR DESCRIPTION
I use SecureRandom in my application server. But it lacks `crypto` module. So this module users add `crypto` manually.
I think library add `crypto` in application list.

Thanks! 
