### PR TITLE
Don't double-encode in urlsafe_base64

### DIFF
--- a/lib/secure_random.ex
+++ b/lib/secure_random.ex
@@ -70,7 +70,7 @@ defmodule SecureRandom do
 
   """
   def urlsafe_base64(n \\ @default_length) do
-    base64(n)
+    random_bytes(n)
     |> Base.url_encode64(case: :lower, padding: true)
   end
 


### PR DESCRIPTION
I tried using this function and the results were longer than they should have been.  This was because it was encoding to standard base64 and then re-encoding *that* to URL-safe base64.  This change fixes that