### PR TITLE
Base.encode64 and url_encode64 do not accept :case as a valid option

### DIFF
--- a/lib/secure_random.ex
+++ b/lib/secure_random.ex
@@ -35,7 +35,7 @@ defmodule SecureRandom do
   """
   def base64(n \\ @default_length) do
     random_bytes(n)
-    |> Base.encode64(case: :lower)
+    |> Base.encode64()
   end
 
   @doc """
@@ -71,7 +71,7 @@ defmodule SecureRandom do
   """
   def urlsafe_base64(n \\ @default_length) do
     base64(n)
-    |> Base.url_encode64(case: :lower, padding: true)
+    |> Base.url_encode64(padding: true)
   end
 
   @doc """


### PR DESCRIPTION
Hello! 

This PR results from an error raised by Dialyzer, when using `SecureRandom.base64()` or `SecureRandom.urlsafe_base64()` in a function `foo/0`:

```
Function foo/0 has no local return.
```

While digging further, it turns out that Dialyzer raises because `Base.encode64()` and `Base.url_encode64()` do not support a `:case` option:

```
The function call will not succeed.

Base.encode64(binary(), [{:case, :lower}])

breaks the contract
(binary(), [{:padding, boolean()}]) :: binary()
```

See the recent elixir docs: https://hexdocs.pm/elixir/Base.html#url_encode64/2 & https://hexdocs.pm/elixir/Base.html#encode64/2. 

I'm not sure if the option ever made sense (or why Dialyzer didn't raise this ealier in my project 🤷‍♀️) - but I hope the PR will at least help other peeps running into this issue, as the original Dialyzer error is cryptic 🥸.